### PR TITLE
Close Pool

### DIFF
--- a/R2SN/network_feature/network.py
+++ b/R2SN/network_feature/network.py
@@ -135,6 +135,7 @@ def network(Image_path,#xxx/xxx/
                             Image_output_path, Mask_path, num_atlas, temp_path,
                             params_path, radiomics_output_path, picked_feature_path,
                             Image_output, radiomics_output, system) for f in Image_list])
+    pool.close()
     shutil.rmtree(temp_path)
 
     # for i in range(len(Image_list)):


### PR DESCRIPTION
If multiprocessing pool is not closed, the program will run forever until terminated. This can cause unexpected issues when debugging.  In some functions the pool is closed automatically, but in this case the pool needs to be closed manually.